### PR TITLE
Added launchMinecraftServer task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,14 +1,18 @@
+import dev.s7a.gradle.minecraft.server.tasks.LaunchMinecraftServerTask
+import dev.s7a.gradle.minecraft.server.tasks.LaunchMinecraftServerTask.JarUrl
+
 plugins {
     java
-    id("io.izzel.taboolib") version "1.42"
-    id("org.jetbrains.kotlin.jvm") version "1.5.31"
+    kotlin("jvm") version "1.9.0"
+    id("io.izzel.taboolib") version "1.56"
+    id("dev.s7a.gradle.minecraft.server") version "3.0.0"
 }
 
 taboolib {
     install("common")
     install("platform-bukkit")
     classifier = null
-    version = "6.0.9-114"
+    version = "6.0.12-26"
 }
 
 repositories {
@@ -26,14 +30,28 @@ tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    kotlinOptions {
-        jvmTarget = "1.8"
-        freeCompilerArgs = listOf("-Xjvm-default=all")
+kotlin {
+    jvmToolchain(17)
+    compilerOptions {
+        freeCompilerArgs.add("-Xjvm-default=all")
     }
 }
 
-configure<JavaPluginConvention> {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+tasks.create<LaunchMinecraftServerTask>("launchMinecraftServer") {
+    // 运行前先构建
+    dependsOn("build")
+
+    // 将构建出来的 Jar 复制到服务器插件文件夹
+    doFirst {
+        copy {
+            from(buildDir.resolve("libs/${project.name}-${project.version}.jar"))
+            into(buildDir.resolve("MinecraftServer/plugins"))
+        }
+    }
+
+    // 是否接受 EULA
+    agreeEula.set(true)
+
+    // 设置服务器核心与版本
+    jarUrl.set(JarUrl.Paper("1.20.2"))
 }


### PR DESCRIPTION
- Added launchMinecraftServer task using "dev.s7a.gradle.minecraft.server" gradle plugin
- Upgraded dependencies
- Upgraded Java versions

Tested with Paper 1.20.2 and 1.19.2, which works fine.
Didn't test with lower version Minecraft that using Java 8 and 16.

It seems that java version of the task is the same with the one gradle used.