### PR TITLE
chore: 升级Gradle和更新Kotlin编译器配置

### DIFF
--- a/.gitignore.ftl
+++ b/.gitignore.ftl
@@ -1,3 +1,15 @@
 .gradle
 .idea
 build
+.kotlin
+bin
+
+### VSCode ###
+.vscode
+
+### Claude Code ###
+.claude
+.claude.local.md
+
+### Cursor ###
+.cursor

--- a/build.gradle.kts.ftl
+++ b/build.gradle.kts.ftl
@@ -1,5 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import io.izzel.taboolib.gradle.*
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
 <#if extraPackages ??>
 <#list extraPackages as extraPackage>
 ${extraPackage}
@@ -70,13 +71,13 @@ tasks.withType<JavaCompile> {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        jvmTarget = "1.8"
-        freeCompilerArgs = listOf("-Xjvm-default=all")
+    compilerOptions {
+        jvmTarget.set(JVM_1_8)
+        freeCompilerArgs.add("-Xjvm-default=all")
     }
 }
 
-configure<JavaPluginConvention> {
+java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
 }

--- a/gradle/wrapper/gradle-wrapper.properties.ftl
+++ b/gradle/wrapper/gradle-wrapper.properties.ftl
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- 将Gradle版本从7.0.2升级到8.14.3
- 更新Kotlin编译器配置以使用新的API
- 替换已弃用的JavaPluginConvention为java扩展

🤖 Generated with [Claude Code](https://claude.ai/code)